### PR TITLE
🚑 fix: update API path for searching coordinates by address

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ class CoordenadasDoCep {
             headers: {
                'User-Agent': 'coordenadas-do-cep-npm-module'
             },
-            path: "/search?country=Brazil&q=" + endereco + "&format=json&limit=1"
+            path: "/search.php?q=" + endereco + "&format=json&limit=1"
          };
 
          try{


### PR DESCRIPTION
The commit updates the API path used for searching coordinates by address in the `CoordenadasDoCep` class. The previous path was "/search?country=Brazil&q=" + endereco + "&format=json&limit=1", and it has been replaced with "/search.php?q=" + endereco + "&format=json&limit=1". This change ensures that the correct API endpoint is being called for retrieving coordinate information.